### PR TITLE
handle widgetId 0

### DIFF
--- a/src/recaptcha.js
+++ b/src/recaptcha.js
@@ -27,14 +27,14 @@ const ReCAPTCHA = React.createClass({
   },
 
   getValue() {
-    if (this.props.grecaptcha && this.state.widgetId) {
+    if (this.props.grecaptcha && this.state.widgetId !== undefined) {
       return this.props.grecaptcha.getResponse(this.state.widgetId);
     }
     return null;
   },
 
   reset() {
-    if (this.props.grecaptcha && this.state.widgetId) {
+    if (this.props.grecaptcha && this.state.widgetId !== undefined) {
       this.props.grecaptcha.reset(this.state.widgetId);
     }
   },
@@ -48,8 +48,7 @@ const ReCAPTCHA = React.createClass({
   },
 
   explicitRender(cb) {
-    if (this.props.grecaptcha && !this.state.widgetId) {
-      this.refs.captcha;
+    if (this.props.grecaptcha && this.state.widgetId === undefined) {
       let id = this.props.grecaptcha.render(this.refs.captcha, {
         sitekey: this.props.sitekey,
         callback: this.props.onChange,


### PR DESCRIPTION
as zero is a valid widgetId (apparently) since tonight. Although we couldn't find something in the docs, it breaks the recaptcha, because `explictRender` is evaluated two times on initialization:

![bildschirmfoto 2015-11-06 um 10 01 47](https://cloud.githubusercontent.com/assets/596578/10993222/71d67942-846d-11e5-9fdc-9868cc1a536f.png)
